### PR TITLE
OPT-253 add: fix bug verstion 2

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -135,7 +135,6 @@ func (c *client) GetUnits(propertyID string) ([]*schema.Unit, error) {
 	}
 
 	req.Header.Set("authorization", c.apiKey)
-	req.Header.Set("version", "2")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
# Discription

When request to api with version 2 not get data like this format:

```json
[
  {
    "id": 4145690,
    "name": "Bldg 6",
    "building_id": "Landlord",
    "property_id": 14612,
    "createdAt": "2022-07-01T18:57:41.269Z",
    "updatedAt": "2024-08-22T14:07:36.977Z"
  },
  {
    "id": 4145634,
    "name": "A01",
    "building_id": "Zone A",
    "property_id": 14612,
    "createdAt": "2022-07-01T18:57:41.267Z",
    "updatedAt": "2024-08-22T14:07:36.976Z"
  },
]

```

Get like this:
[dd.json](https://github.com/user-attachments/files/17213030/dd.json)
